### PR TITLE
Protocol neutral references

### DIFF
--- a/example.html
+++ b/example.html
@@ -173,9 +173,9 @@
 			color: #c33;
 		}
     </style>
-	<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-	<link rel="stylesheet" href="http://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css" />
-	<script src="http://code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+	<link rel="stylesheet" href="//code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css" />
+	<script src="//code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>
 	<script type="text/javascript" src="jquery.mjs.nestedSortable.js"></script>
 	
 	<script>


### PR DESCRIPTION
Github pages use https instead of http. So including js and css from Google CDN via http fails in modern browsers.

<script src="//code.jquery.com/ui/1.10.4/jquery-ui.min.js"></script>

This snippet gets https://code.jquery.com/ui/1.10.4/jquery-ui.min.js on a https enabled site. On a http site  http://code.jquery.com/ui/1.10.4/jquery-ui.min.js is pulled.
