### PR TITLE
Possible solution for triggering relocate event correctly

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -559,9 +559,6 @@
 		},
 
 		_mouseStop: function(event) {
-			var pid,
-				sort;
-
 			// mjs - if the item is in a position not allowed, send it back
 			if (this.beyondMaxLevels) {
 
@@ -588,13 +585,13 @@
 			}
 			this.hovering = null;
 
+			var oldParent = this.currentItem.parent();
+			var oldIndex = this.currentItem.index();
 			$.ui.sortable.prototype._mouseStop.apply(this, arguments);
-
-			pid = $(this.domPosition.parent).parent().attr("id");
-			sort = this.domPosition.prev ? $(this.domPosition.prev).next().index() : 0;
-
-			if (!(pid === this._uiHash().item.parent().parent().attr("id") &&
-				sort === this._uiHash().item.index())) {
+			//see ui.sortable js; this.currentItem is now moved.
+			var newParent = this.currentItem.parent();
+			var currentIndex = this.currentItem.index();
+			if (!(oldParent.is(newParent) && oldIndex == currentIndex)) {
 				this._trigger("relocate", event, this._uiHash());
 			}
 

--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -585,16 +585,10 @@
 			}
 			this.hovering = null;
 
-			var oldParent = this.currentItem.parent();
-			var oldIndex = this.currentItem.index();
-			$.ui.sortable.prototype._mouseStop.apply(this, arguments);
-			//see ui.sortable js; this.currentItem is now moved.
-			var newParent = this.currentItem.parent();
-			var currentIndex = this.currentItem.index();
-			if (!(oldParent.is(newParent) && oldIndex == currentIndex)) {
-				this._trigger("relocate", event, this._uiHash());
-			}
-
+			this._relocate_event = event;
+			this._pid_current = $(this.domPosition.parent).parent().attr("id");
+			this._sort_current = this.domPosition.prev ? $(this.domPosition.prev).next().index() : 0;
+			$.ui.sortable.prototype._mouseStop.apply(this, arguments); //asybnchronous execution, @see _clear for the relocate event.
 		},
 
 		// mjs - this function is slightly modified
@@ -650,6 +644,12 @@
 
 			$.ui.sortable.prototype._clear.apply(this, arguments);
 
+			//relocate event
+			if (!(this._pid_current === this._uiHash().item.parent().parent().attr("id") &&
+				this._sort_current === this._uiHash().item.index())) {
+				this._trigger("relocate", this._relocate_event, this._uiHash());
+			}
+			
 			// mjs - clean last empty ul/ol
 			for (i = this.items.length - 1; i >= 0; i--) {
 				item = this.items[i].item[0];


### PR DESCRIPTION
Try this as a solution; I think this should solve the problem with the relocate event.
I looked at https://github.com/jquery/jquery-ui/blob/master/ui/sortable.js to see that after calling _mouseStop., _clear gets called, and then the item is moved. so on line 591, the currentItem has moved.

*I think this should work but had no time to test this yet*