### PR TITLE
Fixing bug in jQuery selector

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -484,7 +484,7 @@
 				parentItem.after(this.placeholder[0]);
 				helperIsNotSibling = !parentItem
 											.children(o.listItem)
-											.children("li:visible:not(.ui-sortable-helper")
+											.children("li:visible:not(.ui-sortable-helper)")
 											.length;
 				if (o.isTree && helperIsNotSibling) {
 					parentItem


### PR DESCRIPTION
jQuery selector missing right parenthesis--throws an error