### PR TITLE
Top-down dragging causes an issue

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -537,6 +537,7 @@
 					previousItem.children(o.listType)[0].appendChild(this.placeholder[0]);
 				}
 
+				this._clearEmpty(parentItem[0]);
 				this._trigger("change", event, this._uiHash());
 			} else {
 				this._isAllowed(parentItem, level, level + childLevels);


### PR DESCRIPTION
Dragging child item from top to bottom leaves previous temporary parents in an incorrect state: with empty child list and incorrect CSS classes. Dragging in opposite direction works well.