### PR TITLE
Fixed scrolling offset problem.

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -245,7 +245,7 @@
 				this.helper[0].style.left = this.position.left + "px";
 			}
 			if (!this.options.axis || this.options.axis !== "x") {
-				this.helper[0].style.top = (this.position.top + window.scrollY) + "px";
+				this.helper[0].style.top = (this.position.top) + "px";
 			}
 
 			// mjs - check and reset hovering state at each cycle


### PR DESCRIPTION
The top offset for the item being scrolled grew as the page was scrolled down. After two or three scrolls, the item would disappear past the bottom of the viewport. window.scrollY being added to the top offset of the item was the cause of this.