### PR TITLE
_clearEmpty improvements, toArray data collection

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -785,15 +785,15 @@
 				}
 
 				if (id) {
-					        var name = $(item).data("name");
-						ret.push({
-							"id": id[2],
-							"parent_id": pid,
-							"depth": depth,
-							"left": _left,
-							"right": right,
-							"name":name
-						});
+					var data = $(item).children('div').data();
+					var itemObj = $.extend( data, {
+						"id":id[2],
+						"parent_id":pid,
+						"depth":depth,
+						"left":_left,
+						"right":right
+						} );
+					ret.push( itemObj );
 				}
 
 				_left = right + 1;
@@ -813,7 +813,7 @@
 
 			var o = this.options,
 				childrenList = $(item).children(o.listType),
-				hasChildren = childrenList.is(':not(:empty)');
+				hasChildren = childrenList.has('li').length;
 
 			var doNotClear =
 				o.doNotClear ||
@@ -822,13 +822,10 @@
 
 			if (o.isTree) {
 				replaceClass(item, o.branchClass, o.leafClass, doNotClear);
-
-				if (doNotClear && hasChildren) {
-					replaceClass(item, o.collapsedClass, o.expandedClass);
-				}
 			}
 
 			if (!doNotClear) {
+				childrenList.parent().removeClass(o.expandedClass);
 				childrenList.remove();
 			}
 		},


### PR DESCRIPTION
@@ -785,15 +785,15 @@
toArray data() storage/collection should happen on the 'container' element of a leaf, not the leaf itself. That way the nestedSortable.data() does not have to be removed from the object and the data collection allows for more than just data('name')

@@ -813,7 +813,7 @@
:empty recognizes text nodes, this fixes the issue where empty lists were not removed when there was white space left over

@@ -822,13 +822,10 @@
fixes the issue where all branches would open on 'refresh' when isTree is true
fixes the issue where the expandedClass was not removed from the leaf when the childrenList is removed
