### PR TITLE
Fix - toArray bug when called from start event

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -772,7 +772,7 @@
 					depth--;
 				}
 
-				id = ($(item).attr(o.attribute || "id")).match(o.expression || (/(.+)[-=_](.+)/));
+				id = ($(item).attr(o.attribute || "id") || "").match(o.expression || (/(.+)[-=_](.+)/));
 
 				if (depth === sDepth) {
 					pid = o.rootID;


### PR DESCRIPTION
If to "toArray" is called from the "start" event and the dragging has created placeholders it throws an "Uncaught TypeError: Cannot read property 'match' of undefined" error.

toHierarchy and serialize both have this fix already (line 707 and 667) simply applying this also to toArray