### PR TITLE
Expand event receives expanded element

### DIFF
--- a/jquery.mjs.nestedSortable.js
+++ b/jquery.mjs.nestedSortable.js
@@ -338,7 +338,7 @@
 									.addClass(o.expandedClass);
 
 								self.refreshPositions();
-								self._trigger("expand", event, self._uiHash());
+								self._trigger("expand", event, [self._uiHash(), itemElement]);
 							}, o.expandOnHover);
 						}
 					}


### PR DESCRIPTION
The element that is expanded on hover should be passed as an argument to the "expand" event, since it is actually the real subject of the expansion. Most expand callbacks will surely want to know *what* was expanded